### PR TITLE
Fix: removed use of .begin_parse on Slice object.

### DIFF
--- a/dedust/contracts/jettons/jetton_root.py
+++ b/dedust/contracts/jettons/jetton_root.py
@@ -30,7 +30,7 @@ class JettonRoot:
         return {
             "total_supply": stack[0],
             "is_mintable": stack[1] != 0,
-            "admin_address": stack[2].begin_parse().load_address(),
+            "admin_address": stack[2].load_address(),
             "content": stack[3],
             "wallet_code": stack[4]
         }


### PR DESCRIPTION
The value of `stack[2]` is already a Slice, so we don't to call `.begin_parse` here.